### PR TITLE
Locked the omniauth-oauth2 version to 1.3.1

### DIFF
--- a/omniauth-mlh.gemspec
+++ b/omniauth-mlh.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.0'
-  spec.add_dependency 'omniauth-oauth2', '>= 1.1.1', '< 2.0'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.3.1'
 
   spec.add_development_dependency 'rspec', '~> 2.7'
   spec.add_development_dependency 'rack-test'


### PR DESCRIPTION
https://github.com/intridea/omniauth-oauth2/pull/70 introduced a
breaking change for a number of oauth providers.  Right now the
recommended fix is to lock to 1.3.1

Here's the relevant doorkeeper discussion.
https://github.com/doorkeeper-gem/doorkeeper/issues/737
