### PR TITLE
[DEV-3974] Enable PKCE by default and allow credential omission

### DIFF
--- a/lib/omniauth-mlh/version.rb
+++ b/lib/omniauth-mlh/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module MLH
-    VERSION = '4.1.1'
+    VERSION = '4.2.0'
   end
 end

--- a/lib/omniauth/strategies/mlh.rb
+++ b/lib/omniauth/strategies/mlh.rb
@@ -33,20 +33,12 @@ module OmniAuth
         site: 'https://www.mlh.com',
         authorize_url: '/oauth/authorize',
         token_url: 'https://api.mlh.com/v4/oauth/token',
-        # Base for the OAuth2 API (user info). Override when the API lives on a
-        # different origin than the default production MyMLH API.
         api_site: 'https://api.mlh.com',
         auth_scheme: :request_body # Change from basic auth to request body
       }
 
-      # Enable PKCE (S256) by default; override with pkce: false for clients that cannot use it
       option :pkce, true
 
-      # When false, provider tokens are blanked in the auth hash before it
-      # reaches the host application. Deployments that never call the MLH API
-      # on the user's behalf (or proxy through another service) use this to
-      # avoid storing bearer material at all. Defaults to true so existing
-      # consumers keep receiving working credentials.
       option :persist_credentials, true
 
       # Support expandable fields through options
@@ -93,16 +85,14 @@ module OmniAuth
         symbolize_nested_arrays(data)
       end
 
-      # omniauth-oauth2 builds this from the access token; when the host asked
-      # us not to persist credentials we hand back a shaped-but-empty copy so
-      # downstream persistence stores nothing sensitive.
+      # Preserve the OmniAuth credential shape without exposing bearer material.
       def credentials
         return super if options.persist_credentials
 
         OmniAuth::AuthHash.new(
-          token: "",
+          token: '',
           refresh_token: nil,
-          secret: "",
+          secret: '',
           expires: false
         )
       end
@@ -110,7 +100,7 @@ module OmniAuth
       def build_api_url
         base = (options.dig(:client_options, :api_site) || 'https://api.mlh.com').to_s.chomp('/')
         url = "#{base}/v4/users/me"
-        expand_fields = options[:expand_fields] || []
+        expand_fields = options[:expand_fields]
         return url if expand_fields.empty?
 
         expand_query = expand_fields.map { |f| "expand[]=#{f}" }.join('&')

--- a/lib/omniauth/strategies/mlh.rb
+++ b/lib/omniauth/strategies/mlh.rb
@@ -42,6 +42,13 @@ module OmniAuth
       # Enable PKCE (S256) by default; override with pkce: false for clients that cannot use it
       option :pkce, true
 
+      # When false, provider tokens are blanked in the auth hash before it
+      # reaches the host application. Deployments that never call the MLH API
+      # on the user's behalf (or proxy through another service) use this to
+      # avoid storing bearer material at all. Defaults to true so existing
+      # consumers keep receiving working credentials.
+      option :persist_credentials, true
+
       # Support expandable fields through options
       option :expand_fields, []
 
@@ -84,6 +91,20 @@ module OmniAuth
         return {} unless data.is_a?(Hash)
 
         symbolize_nested_arrays(data)
+      end
+
+      # omniauth-oauth2 builds this from the access token; when the host asked
+      # us not to persist credentials we hand back a shaped-but-empty copy so
+      # downstream persistence stores nothing sensitive.
+      def credentials
+        return super if options.persist_credentials
+
+        OmniAuth::AuthHash.new(
+          token: "",
+          refresh_token: nil,
+          secret: "",
+          expires: false
+        )
       end
 
       def build_api_url

--- a/lib/omniauth/strategies/mlh.rb
+++ b/lib/omniauth/strategies/mlh.rb
@@ -33,8 +33,14 @@ module OmniAuth
         site: 'https://www.mlh.com',
         authorize_url: '/oauth/authorize',
         token_url: 'https://api.mlh.com/v4/oauth/token',
+        # Base for the OAuth2 API (user info). Override when the API lives on a
+        # different origin than the default production MyMLH API.
+        api_site: 'https://api.mlh.com',
         auth_scheme: :request_body # Change from basic auth to request body
       }
+
+      # Enable PKCE (S256) by default; override with pkce: false for clients that cannot use it
+      option :pkce, true
 
       # Support expandable fields through options
       option :expand_fields, []
@@ -65,7 +71,8 @@ module OmniAuth
 
       def data
         @data ||= fetch_and_process_data.compact
-      rescue StandardError
+      rescue ::OAuth2::Error, JSON::ParserError => e
+        OmniAuth.logger.warn("OmniAuth MLH: failed to load user data (#{e.class})")
         {}
       end
 
@@ -80,7 +87,8 @@ module OmniAuth
       end
 
       def build_api_url
-        url = 'https://api.mlh.com/v4/users/me'
+        base = (options.dig(:client_options, :api_site) || 'https://api.mlh.com').to_s.chomp('/')
+        url = "#{base}/v4/users/me"
         expand_fields = options[:expand_fields] || []
         return url if expand_fields.empty?
 

--- a/lib/omniauth/strategies/mlh.rb
+++ b/lib/omniauth/strategies/mlh.rb
@@ -100,7 +100,7 @@ module OmniAuth
       def build_api_url
         base = (options.dig(:client_options, :api_site) || 'https://api.mlh.com').to_s.chomp('/')
         url = "#{base}/v4/users/me"
-        expand_fields = options[:expand_fields]
+        expand_fields = options[:expand_fields] || []
         return url if expand_fields.empty?
 
         expand_query = expand_fields.map { |f| "expand[]=#{f}" }.join('&')

--- a/spec/omni_auth/mlh_spec.rb
+++ b/spec/omni_auth/mlh_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe OmniAuth::MLH do
   it 'has a version number' do
     expect(OmniAuth::MLH::VERSION).not_to be_nil
-    expect(OmniAuth::MLH::VERSION).to eq('4.1.1')
+    expect(OmniAuth::MLH::VERSION).to eq('4.2.0')
   end
 
   it 'loads the MLH strategy' do

--- a/spec/omni_auth/strategies/mlh_spec.rb
+++ b/spec/omni_auth/strategies/mlh_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'uri'
 
 RSpec.describe OmniAuth::Strategies::MLH do
   let(:strategy) { described_class.new(app, 'client_id', 'client_secret') }
@@ -81,6 +82,29 @@ RSpec.describe OmniAuth::Strategies::MLH do
       end
     end
 
+    context 'with a custom api_site client option' do
+      let(:custom_strategy) do
+        described_class.new(app, 'client_id', 'client_secret',
+                            client_options: { api_site: 'https://api.mlh.test' })
+      end
+
+      let(:response) do
+        instance_double(OAuth2::Response, body: { 'id' => 'core-user-1' }.to_json)
+      end
+
+      before do
+        allow(custom_strategy).to receive(:access_token).and_return(access_token)
+      end
+
+      it 'fetches user data from the configured API base' do
+        expect(access_token).to receive(:get)
+          .with('https://api.mlh.test/v4/users/me')
+          .and_return(response)
+
+        expect(custom_strategy.data[:id]).to eq('core-user-1')
+      end
+    end
+
     context 'with v4 API complex data structures' do
       include_context 'with oauth response', {
         'id' => 'test-id',
@@ -150,10 +174,42 @@ RSpec.describe OmniAuth::Strategies::MLH do
     end
 
     context 'with API error' do
-      it 'returns empty hash on error' do
-        allow(access_token).to receive(:get).and_raise(StandardError)
+      context 'with OAuth2::Error' do
+        let(:error_response) do
+          instance_double(OAuth2::Response, status: 500, headers: {},
+                                          body: '{"error": "server_error"}')
+        end
 
-        expect(strategy.data).to eq({})
+        before do
+          allow(access_token).to receive(:get).and_raise(OAuth2::Error.new(error_response))
+        end
+
+        it 'returns empty payload for OAuth2 errors' do
+          expect(strategy.data).to eq({})
+        end
+      end
+
+      context 'with malformed JSON' do
+        before do
+          allow(access_token).to receive(:get)
+            .and_return(instance_double(OAuth2::Response, body: '<html>not json</html>'))
+        end
+
+        it 'returns empty payload for JSON parse failures' do
+          expect(strategy.data).to eq({})
+        end
+      end
+
+      context 'with unexpected error' do
+        let(:unexpected_error_class) { Class.new(StandardError) }
+
+        before do
+          allow(access_token).to receive(:get).and_raise(unexpected_error_class, 'boom')
+        end
+
+        it 'propagates unexpected errors' do
+          expect { strategy.data }.to raise_error(unexpected_error_class)
+        end
       end
     end
   end
@@ -198,6 +254,62 @@ RSpec.describe OmniAuth::Strategies::MLH do
 
     it 'includes user roles' do
       expect(strategy.info[:roles]).to eq(['hacker'])
+    end
+  end
+
+  describe 'PKCE authorization' do
+    before { OmniAuth.config.test_mode = true }
+
+    after { OmniAuth.config.test_mode = false }
+
+    it 'is enabled by default' do
+      expect(strategy.options.pkce).to be(true)
+    end
+
+    it 'includes a code_challenge and S256 method in the authorization params' do
+      params = strategy.authorize_params
+
+      expect(params[:code_challenge]).to be_present
+      expect(params[:code_challenge_method]).to eq('S256')
+    end
+
+    it 'does not include code_verifier in the authorization URL' do
+      allow(strategy).to receive(:callback_url).and_return('http://localhost:8765/callback')
+
+      url = strategy.client.auth_code.authorize_url(
+        { redirect_uri: strategy.callback_url }.merge(strategy.authorize_params)
+      )
+      query = URI.decode_www_form(URI(url).query).to_h
+
+      expect(query['code_challenge']).to be_present
+      expect(query['code_challenge_method']).to eq('S256')
+      expect(query).not_to have_key('code_verifier')
+    end
+
+    it 'sends the matching code_verifier on the token exchange' do
+      strategy.authorize_params
+
+      expect(strategy.token_params[:code_verifier]).to eq(strategy.options.pkce_verifier)
+      expect(strategy.options.pkce_verifier).to be_present
+    end
+
+    it 'can be disabled via the pkce option' do
+      strategy = described_class.new(app, 'client_id', 'client_secret', pkce: false)
+
+      expect(strategy.authorize_params).not_to include(:code_challenge, :code_challenge_method)
+      expect(strategy.token_params).not_to have_key(:code_verifier)
+    end
+  end
+
+  describe 'security defaults' do
+    it 'keeps state validation enabled' do
+      expect(strategy.options.provider_ignores_state).to be_falsey
+    end
+
+    it 'remains a confidential client using request-body authentication' do
+      expect(strategy.client.id).to eq('client_id')
+      expect(strategy.client.secret).to eq('client_secret')
+      expect(strategy.options.client_options.auth_scheme).to eq(:request_body)
     end
   end
 end

--- a/spec/omni_auth/strategies/mlh_spec.rb
+++ b/spec/omni_auth/strategies/mlh_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe OmniAuth::Strategies::MLH do
                       body: response_data.to_json,
                       parsed: response_data)
     end
+
     before do
       allow(access_token).to receive(:get)
         .with('https://api.mlh.com/v4/users/me')
@@ -93,14 +94,15 @@ RSpec.describe OmniAuth::Strategies::MLH do
 
       before do
         allow(custom_strategy).to receive(:access_token).and_return(access_token)
+        allow(access_token).to receive(:get)
+          .with('https://api.mlh.test/v4/users/me')
+          .and_return(response)
       end
 
       it 'fetches user data from the configured API base' do
-        expect(access_token).to receive(:get)
-          .with('https://api.mlh.test/v4/users/me')
-          .and_return(response)
+        custom_strategy.data
 
-        expect(custom_strategy.data[:id]).to eq('core-user-1')
+        expect(access_token).to have_received(:get).with('https://api.mlh.test/v4/users/me')
       end
     end
 
@@ -172,43 +174,43 @@ RSpec.describe OmniAuth::Strategies::MLH do
       end
     end
 
-    context 'with API error' do
-      context 'with OAuth2::Error' do
-        let(:error_response) do
-          instance_double(OAuth2::Response, status: 500, headers: {},
-                                          body: '{"error": "server_error"}')
-        end
-
-        before do
-          allow(access_token).to receive(:get).and_raise(OAuth2::Error.new(error_response))
-        end
-
-        it 'returns empty payload for OAuth2 errors' do
-          expect(strategy.data).to eq({})
-        end
+    context 'with OAuth2::Error' do
+      let(:error_response) do
+        instance_double(OAuth2::Response,
+                        status: 500,
+                        headers: {},
+                        body: '{"error": "server_error"}')
       end
 
-      context 'with malformed JSON' do
-        before do
-          allow(access_token).to receive(:get)
-            .and_return(instance_double(OAuth2::Response, body: '<html>not json</html>'))
-        end
-
-        it 'returns empty payload for JSON parse failures' do
-          expect(strategy.data).to eq({})
-        end
+      before do
+        allow(access_token).to receive(:get).and_raise(OAuth2::Error.new(error_response))
       end
 
-      context 'with unexpected error' do
-        let(:unexpected_error_class) { Class.new(StandardError) }
+      it 'returns empty payload for OAuth2 errors' do
+        expect(strategy.data).to eq({})
+      end
+    end
 
-        before do
-          allow(access_token).to receive(:get).and_raise(unexpected_error_class, 'boom')
-        end
+    context 'with malformed JSON' do
+      before do
+        allow(access_token).to receive(:get)
+          .and_return(instance_double(OAuth2::Response, body: '<html>not json</html>'))
+      end
 
-        it 'propagates unexpected errors' do
-          expect { strategy.data }.to raise_error(unexpected_error_class)
-        end
+      it 'returns empty payload for JSON parse failures' do
+        expect(strategy.data).to eq({})
+      end
+    end
+
+    context 'with unexpected error' do
+      let(:unexpected_error_class) { Class.new(StandardError) }
+
+      before do
+        allow(access_token).to receive(:get).and_raise(unexpected_error_class, 'boom')
+      end
+
+      it 'propagates unexpected errors' do
+        expect { strategy.data }.to raise_error(unexpected_error_class)
       end
     end
   end
@@ -218,17 +220,21 @@ RSpec.describe OmniAuth::Strategies::MLH do
       described_class.new(app, 'client_id', 'client_secret', persist_credentials: false)
     end
 
+    let(:empty_credentials) do
+      {
+        'token' => '',
+        'refresh_token' => nil,
+        'secret' => '',
+        'expires' => false
+      }
+    end
+
     before do
       allow(strategy).to receive(:data).and_return(id: 'core-user-1')
     end
 
     it 'omits bearer credentials when persistence is disabled' do
-      expect(strategy.auth_hash['credentials']).to eq(
-        'token' => '',
-        'refresh_token' => nil,
-        'secret' => '',
-        'expires' => false
-      )
+      expect(strategy.auth_hash['credentials']).to eq(empty_credentials)
     end
   end
 
@@ -282,13 +288,10 @@ RSpec.describe OmniAuth::Strategies::MLH do
 
     it 'uses S256 by default and sends the verifier only in token params' do
       params = strategy.authorize_params
-      verifier = strategy.options.pkce_verifier
 
-      expect(params[:code_challenge]).to be_present
-      expect(params[:code_challenge_method]).to eq('S256')
+      expect(params).to include(code_challenge: be_present, code_challenge_method: 'S256')
       expect(params).not_to have_key(:code_verifier)
-      expect(verifier).to be_present
-      expect(strategy.token_params[:code_verifier]).to eq(verifier)
+      expect(strategy.token_params[:code_verifier]).to eq(strategy.options.pkce_verifier).and be_present
     end
 
     it 'can be disabled via the pkce option' do

--- a/spec/omni_auth/strategies/mlh_spec.rb
+++ b/spec/omni_auth/strategies/mlh_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'uri'
 
 RSpec.describe OmniAuth::Strategies::MLH do
   let(:strategy) { described_class.new(app, 'client_id', 'client_secret') }
@@ -79,36 +78,6 @@ RSpec.describe OmniAuth::Strategies::MLH do
 
       it 'returns an empty hash for empty data' do
         expect(strategy.data).to eq({})
-      end
-    end
-
-    context 'with persist_credentials disabled' do
-      let(:custom_strategy) do
-        described_class.new(app, 'client_id', 'client_secret',
-                            client_options: { api_site: 'https://api.mlh.test' },
-                            persist_credentials: false)
-      end
-
-      let(:response) do
-        instance_double(OAuth2::Response, body: { 'id' => 'core-user-1' }.to_json)
-      end
-
-      before do
-        allow(custom_strategy).to receive(:access_token).and_return(access_token)
-        allow(access_token).to receive(:token).and_return('real-token')
-        allow(access_token).to receive(:refresh_token).and_return('real-refresh')
-      end
-
-      it 'blanks every bearer field in the auth hash credentials' do
-        expect(access_token).to receive(:get)
-          .with('https://api.mlh.test/v4/users/me')
-          .and_return(response)
-
-        hash = custom_strategy.auth_hash
-
-        expect(hash['credentials']['token']).to eq('')
-        expect(hash['credentials']['refresh_token']).to be_nil
-        expect(hash['credentials']['secret']).to eq('')
       end
     end
 
@@ -244,6 +213,25 @@ RSpec.describe OmniAuth::Strategies::MLH do
     end
   end
 
+  describe '#auth_hash' do
+    let(:strategy) do
+      described_class.new(app, 'client_id', 'client_secret', persist_credentials: false)
+    end
+
+    before do
+      allow(strategy).to receive(:data).and_return(id: 'core-user-1')
+    end
+
+    it 'omits bearer credentials when persistence is disabled' do
+      expect(strategy.auth_hash['credentials']).to eq(
+        'token' => '',
+        'refresh_token' => nil,
+        'secret' => '',
+        'expires' => false
+      )
+    end
+  end
+
   describe '#uid' do
     context 'with valid data' do
       it 'returns the id from the data hash' do
@@ -292,54 +280,22 @@ RSpec.describe OmniAuth::Strategies::MLH do
 
     after { OmniAuth.config.test_mode = false }
 
-    it 'is enabled by default' do
-      expect(strategy.options.pkce).to be(true)
-    end
-
-    it 'includes a code_challenge and S256 method in the authorization params' do
+    it 'uses S256 by default and sends the verifier only in token params' do
       params = strategy.authorize_params
+      verifier = strategy.options.pkce_verifier
 
       expect(params[:code_challenge]).to be_present
       expect(params[:code_challenge_method]).to eq('S256')
-    end
-
-    it 'does not include code_verifier in the authorization URL' do
-      allow(strategy).to receive(:callback_url).and_return('http://localhost:8765/callback')
-
-      url = strategy.client.auth_code.authorize_url(
-        { redirect_uri: strategy.callback_url }.merge(strategy.authorize_params)
-      )
-      query = URI.decode_www_form(URI(url).query).to_h
-
-      expect(query['code_challenge']).to be_present
-      expect(query['code_challenge_method']).to eq('S256')
-      expect(query).not_to have_key('code_verifier')
-    end
-
-    it 'sends the matching code_verifier on the token exchange' do
-      strategy.authorize_params
-
-      expect(strategy.token_params[:code_verifier]).to eq(strategy.options.pkce_verifier)
-      expect(strategy.options.pkce_verifier).to be_present
+      expect(params).not_to have_key(:code_verifier)
+      expect(verifier).to be_present
+      expect(strategy.token_params[:code_verifier]).to eq(verifier)
     end
 
     it 'can be disabled via the pkce option' do
-      strategy = described_class.new(app, 'client_id', 'client_secret', pkce: false)
+      disabled_strategy = described_class.new(app, 'client_id', 'client_secret', pkce: false)
 
-      expect(strategy.authorize_params).not_to include(:code_challenge, :code_challenge_method)
-      expect(strategy.token_params).not_to have_key(:code_verifier)
-    end
-  end
-
-  describe 'security defaults' do
-    it 'keeps state validation enabled' do
-      expect(strategy.options.provider_ignores_state).to be_falsey
-    end
-
-    it 'remains a confidential client using request-body authentication' do
-      expect(strategy.client.id).to eq('client_id')
-      expect(strategy.client.secret).to eq('client_secret')
-      expect(strategy.options.client_options.auth_scheme).to eq(:request_body)
+      expect(disabled_strategy.authorize_params).not_to include(:code_challenge, :code_challenge_method)
+      expect(disabled_strategy.token_params).not_to have_key(:code_verifier)
     end
   end
 end

--- a/spec/omni_auth/strategies/mlh_spec.rb
+++ b/spec/omni_auth/strategies/mlh_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe OmniAuth::Strategies::MLH do
       end
     end
 
+    context 'with persist_credentials disabled' do
+      let(:custom_strategy) do
+        described_class.new(app, 'client_id', 'client_secret',
+                            client_options: { api_site: 'https://api.mlh.test' },
+                            persist_credentials: false)
+      end
+
+      let(:response) do
+        instance_double(OAuth2::Response, body: { 'id' => 'core-user-1' }.to_json)
+      end
+
+      before do
+        allow(custom_strategy).to receive(:access_token).and_return(access_token)
+        allow(access_token).to receive(:token).and_return('real-token')
+        allow(access_token).to receive(:refresh_token).and_return('real-refresh')
+      end
+
+      it 'blanks every bearer field in the auth hash credentials' do
+        expect(access_token).to receive(:get)
+          .with('https://api.mlh.test/v4/users/me')
+          .and_return(response)
+
+        hash = custom_strategy.auth_hash
+
+        expect(hash['credentials']['token']).to eq('')
+        expect(hash['credentials']['refresh_token']).to be_nil
+        expect(hash['credentials']['secret']).to eq('')
+      end
+    end
+
     context 'with a custom api_site client option' do
       let(:custom_strategy) do
         described_class.new(app, 'client_id', 'client_secret',

--- a/spec/omni_auth/strategies/mlh_spec.rb
+++ b/spec/omni_auth/strategies/mlh_spec.rb
@@ -17,6 +17,31 @@ RSpec.describe OmniAuth::Strategies::MLH do
       expect(strategy.options.client_options.authorize_url).to eq('/oauth/authorize')
       expect(strategy.options.client_options.token_url).to eq('https://api.mlh.com/v4/oauth/token')
     end
+
+    context 'with only api_site overridden' do
+      let(:strategy) do
+        described_class.new(app, 'client_id', 'client_secret',
+                            client_options: { api_site: 'https://api.mlh.test' })
+      end
+
+      let(:token_request) do
+        stub_request(:post, 'https://api.mlh.com/v4/oauth/token')
+          .with(body: hash_including('client_id' => 'client_id', 'client_secret' => 'client_secret',
+                                     'code' => 'authorization-code', 'grant_type' => 'authorization_code'))
+          .to_return(body: { access_token: 'test-token', token_type: 'Bearer' }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'preserves the OAuth authorization endpoint' do
+        expect(strategy.client.authorize_url).to eq('https://www.mlh.com/oauth/authorize')
+      end
+
+      it 'exchanges a code at the default token endpoint with credentials in the request body' do
+        token_request
+        expect(strategy.client.auth_code.get_token('authorization-code').token).to eq('test-token')
+        expect(token_request).to have_been_requested
+      end
+    end
   end
 
   shared_context 'with oauth response' do |response_data|
@@ -34,6 +59,21 @@ RSpec.describe OmniAuth::Strategies::MLH do
   end
 
   describe '#data' do
+    [nil, false].each do |expand_fields|
+      context "with expand_fields set to #{expand_fields.inspect}" do
+        let(:strategy) do
+          described_class.new(app, 'client_id', 'client_secret', expand_fields: expand_fields)
+        end
+
+        include_context 'with oauth response', { 'id' => 'core-user-1' }
+
+        it 'fetches user data without expansion parameters' do
+          expect(strategy.data).to eq(id: 'core-user-1')
+          expect(access_token).to have_received(:get).with('https://api.mlh.com/v4/users/me')
+        end
+      end
+    end
+
     context 'with expandable fields' do
       let(:response) do
         instance_double(OAuth2::Response, body: {}.to_json, parsed: {})


### PR DESCRIPTION
## Summary

- Enable PKCE by default.
- Make the MLH API base configurable.
- Narrow OAuth error rescue behavior.
- Allow consumers to omit persisted OAuth credentials.
- Prepare version 4.2.0 for the dependent Forem integration.

## Dependency

This is the standalone cross-fork dependency for the Forem DEV-3974 stack. GitHub native stacks cannot cross repositories.

## Status

Draft only. Do not publish the gem or merge the dependent Forem layer until focused review and release checks are complete.

## Security review

The complete committed delta was audited. No tracked environment file, literal credential, token, private key, credential-bearing URL, real identity fixture, or generated secret artifact was found.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MLH/codesmith/omniauth-mlh/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790642479&installation_model_id=427356&pr_number=19&repository=MLH%2Fomniauth-mlh&return_to=https%3A%2F%2Fgithub.com%2FMLH%2Fomniauth-mlh%2Fpull%2F19&signature=177c1e6a477d63fd9d5ac330021ab397fe69375dccdea2504e617b6f40af4470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->